### PR TITLE
Fetching providers list message is not visible in darkmode #15

### DIFF
--- a/src/popup/sass/components/_darkmode.scss
+++ b/src/popup/sass/components/_darkmode.scss
@@ -9,10 +9,16 @@ body.dark {
     color: $color-white !important;
   }
 
-  input::placeholder {
+  input::-webkit-input-placeholder {
     color: $color-white !important;
   }
-  
+  input::-moz-placeholder {
+    color: $color-white !important;
+  }
+  input:-ms-input-placeholder {
+    color: $color-white !important;
+  }
+
   .popup__body {
     background-color: $color-darkmode-1 !important ;
   }

--- a/src/popup/sass/components/_darkmode.scss
+++ b/src/popup/sass/components/_darkmode.scss
@@ -9,6 +9,10 @@ body.dark {
     color: $color-white !important;
   }
 
+  input::placeholder {
+    color: $color-white !important;
+  }
+  
   .popup__body {
     background-color: $color-darkmode-1 !important ;
   }


### PR DESCRIPTION
Fixes #15 

**Description**
- Pseudo-css classes were added to change the color of the input placeholder in darkmode.

** My commits **
- Add pseudo-class css for input in darkmode
- Add pseudo class css for others browsers


