### PR TITLE
Let the user to only search for terms with alpha-numeric characters #14

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -226,7 +226,7 @@ elements.filterApplyButton.addEventListener('click', () => {
 });
 
 elements.searchIcon.addEventListener('click', () => {
-  inputText = elements.inputField.value;
+  inputText = elements.inputField.value().trim().replace('/[ ]+/g', ' ');
   pageNo = 1;
 
   checkInputError(inputText, 'error-message');

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -13,6 +13,10 @@ export function checkInputError(inputText) {
     showNotification('No search query provided', 'negative', 'snackbar-bookmarks');
     // to stop further js execution
     throw new Error('No search query provided');
+  } else if (!/^[A-Za-z0-9 ]+$/.test(inputText)) {
+    showNotification('No valid search query provided, search query must be alphanumeric', 'negative', 'snackbar-bookmarks');
+    // to stop further js execution
+    throw new Error('No valid search query provided');
   }
 }
 

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -13,7 +13,7 @@ export function checkInputError(inputText) {
     showNotification('No search query provided', 'negative', 'snackbar-bookmarks');
     // to stop further js execution
     throw new Error('No search query provided');
-  } else if (!/^[A-Za-z0-9 ]+$/.test(inputText)) {
+  } else if (!/^[A-Za-z0-9]( ?[A-Za-z0-9])*$/.test(inputText)) {
     showNotification('No valid search query provided, search query must be alphanumeric', 'negative', 'snackbar-bookmarks');
     // to stop further js execution
     throw new Error('No valid search query provided');

--- a/tests/searchModule.test.js
+++ b/tests/searchModule.test.js
@@ -17,13 +17,25 @@ test('testing checkInputError', () => {
     'snackbar-bookmarks',
   );
 
+  // testing checkInputError with not alphanumeric search query
+  expect(() => {
+    checkInputError('not alpha-numeric');
+  }).toThrow('No valid search query provided');
+
+  expect(utils.showNotification).toHaveBeenCalled();
+  expect(utils.showNotification).toHaveBeenCalledWith(
+    'No valid search query provided, search query must be alphanumeric',
+    'negative',
+    'snackbar-bookmarks',
+  );
+
   // testing checkInputError with a non-empty search
   expect(() => {
     checkInputError('dogs');
   }).not.toThrow('No search query provided');
 
   // showNotification should be called only in case of empty search query
-  expect(utils.showNotification).toHaveBeenCalledTimes(1);
+  expect(utils.showNotification).toHaveBeenCalledTimes(2);
 });
 
 test('testing getRequestUrl', () => {


### PR DESCRIPTION
Fixes #14 

**Description**
Added alpha-numeric search validation.

**My commits**
- Add alpha-numeric validation on search
- Add alpha-numeric validation test
