### PR TITLE
Add troubleshooting steps for build failures when webpack-cli is not properly installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ You can install the extension directly from the source. Follow the following ste
       - Click on "Load Unpacked" button (make sure you have enabled the _Developer mode_).
       - From the file explorer, choose `ccsearch-browser-extension/dist/opera`.
 
+## Troubleshooting buid failures
+1. If you get following error:
+```shell
+'TARGET' is not recognized as an internal or external command
+```
+then most likely webpack-cli is not installed on your dev machine.
+
+- Here are the few things you can try:
+  - Try deleting the folder node_modules and reinstalling webpack-cli
+```shell
+  npm install --save-dev webpack-cli
+  ```
+  - if reinstalling node modules do not solve the issue then run following to install webpack-cli globally.
+  ```shell
+  npm install -g webpack-cli
+  ```
+
 ## Contribution
 Checkout [CONTRIBUTING.md](https://github.com/creativecommons/ccsearch-browser-extension/blob/master/CONTRIBUTING.md) for general guidelines for contributing code to CC Open Source.
 


### PR DESCRIPTION
Add troubleshooting steps for build failures when webpack-cli is not properly installed

**Description**
<!-- Add your description below. -->
Update README.md to add section for troubleshooting dev-setup/build failures

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

