### PR TITLE
Error while downloading images in absence of content script

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,1 +1,0 @@
-// temporary solution to https://github.com/creativecommons/ccsearch-browser-extension/issues/8

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -20,15 +20,12 @@
     },
     "default_popup": "popup/popup.html"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage",
+    "https://*/"
+
+  ],
   "options_ui": {
     "page": "options/options.html",
     "open_in_tab": true
-  },
-  "content_scripts": [
-    {
-      "matches": ["https://*/*"],
-      "js": ["content.js"]
-    }
-  ]
+  }
 }

--- a/src/manifest.opera.json
+++ b/src/manifest.opera.json
@@ -20,15 +20,9 @@
     },
     "default_popup": "popup/popup.html"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "https://*/"],
   "options_ui": {
     "page": "options/options.html",
     "open_in_tab": true
-  },
-  "content_scripts": [
-    {
-      "matches": ["https://*/*"],
-      "js": ["content.js"]
-    }
-  ]
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,10 +36,6 @@ module.exports = {
         to: './manifest.json',
       },
       {
-        from: './content.js',
-        to: './content.js',
-      },
-      {
         from: './icons/*',
         to: './icons',
         flatten: true,


### PR DESCRIPTION
**[Issue #8]**
The following error occurs when trying to download a photo from Behance
provider:
`popup.html:1 Access to XMLHttpRequest at 'https://mir-s3-cdn-cf.behance
.net/project_modules/max_1200/180a6536683721.5725932eb3e24.jpg' from
origin 'chrome-extension://obckdhkhgdbigeihagclikjmlioanfbb' has been
blocked by CORS policy: No 'Access-Control-Allow-Origin' header is
present on the requested resource.`

**[Cause]**
Regular web pages can use the XMLHttpRequest object to send and receive
data from remote servers, but they're limited by the same origin policy
(and since Chrome 73 content scripts are also subject to the same
restrictions as the web page they are injected into). Extensions aren't
so limited - a script executing in an extension's origin can talk to
remote servers outside of its origin, as long as the extension requests
cross-origin permissions.

**[Fix]**
Add request for permission to download images from all https:// websites
Avoids cross-site scripting vulnerabilities.
More in-depth information can be read here:
[chrome developer extension](https://developer.chrome.com/extensions/xhr)

Fixes #8 


<!-- Make sure you read and understand the following attestation. -->

**Developer Certificate of Origin**
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

