### PR TITLE
Fix#33 : Bookmark page's footer is out of place

### DIFF
--- a/src/popup/sass/layout/_footer.scss
+++ b/src/popup/sass/layout/_footer.scss
@@ -2,6 +2,10 @@ footer {
   height: 2.5rem;
   background-color: #242424;
   text-align: center;
+  position: fixed;
+  width: 100%;
+  bottom: 0px;
+  z-index: 10;
 }
 
 .footer-box {


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #33 

**Description**
<!-- Add your description below. -->
This fix is for Bookmark page's footer out of place. Made the changes in _footer.scss to set the **footer fixed at the bottom** of the extension window and set its **z-index** < Popup && **z-index** > rest of the sections.
 
**My commit**
- fix-#33 Bookmark page's footer is out of place.