### PR TITLE
Changed popup heading styles

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -127,10 +127,10 @@
         <div id="spinner-placeholder--popup"></div>
         <div class="popup__main">
           <div id="attribution" class="popup__tab-content">
-            <h3 class="attribution-label margin-bottom-small">Rich-text</h3>
+            <h6 class="vocab heading">Rich-text</h6>
             <p id="attribution-rich-text" class="margin-bottom-small"></p>
             <button class="btn-popup btn-copy" data-clipboard-target="#attribution-rich-text">Copy</button>
-            <h3 class="attribution-label margin-bottom-small margin-top-medium">HTML</h3>
+            <h6 class="vocab heading">HTML</h6>
             <textarea class="margin-bottom-small" id="attribution-html" id="" cols="30" rows="3" readonly>
             text area
           </textarea

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -130,7 +130,7 @@
             <h6 class="vocab heading">Rich-text</h6>
             <p id="attribution-rich-text" class="margin-bottom-small"></p>
             <button class="btn-popup btn-copy" data-clipboard-target="#attribution-rich-text">Copy</button>
-            <h6 class="vocab heading">HTML</h6>
+            <h6 class="vocab heading margin-top-medium">HTML</h6>
             <textarea class="margin-bottom-small" id="attribution-html" id="" cols="30" rows="3" readonly>
             text area
           </textarea

--- a/src/popup/sass/components/_popup.scss
+++ b/src/popup/sass/components/_popup.scss
@@ -34,12 +34,6 @@
       display: block;
     }
 
-    .attribution-label {
-      text-decoration: none;
-      font-weight: 700;
-      font-size: $size-normal;
-    }
-
     #attribution-rich-text {
       font-size: 0.875rem;
       font-weight: 500;


### PR DESCRIPTION
Fixes #37 

**Description**
Changed heading styles to integrate CC-vocabulary.

**Checklist:**
- [x] My pull request has a descriptive title.
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

