### PR TITLE
Replace infinite scrolling with voluntary loading using load more button

### DIFF
--- a/src/popup/base.js
+++ b/src/popup/base.js
@@ -18,6 +18,8 @@ export const elements = {
   filterResetButton: document.querySelector('.section-filter--reset-button'),
   filterApplyButton: document.querySelector('.section-filter--apply-button'),
   noMoreImagesMessage: document.querySelector('.no-more-images-mes'),
+  loadMoreButton: document.querySelector('.load-more-button'),
+  loadMoreButtonWrapper: document.querySelector('.load-more-button-wrapper'),
   popup: document.getElementById('popup'),
   popupMain: document.querySelector('.popup__main'),
   downloadImageButton: document.getElementById('download-image'),

--- a/src/popup/bookmarkModule.js
+++ b/src/popup/bookmarkModule.js
@@ -1,6 +1,6 @@
 import { elements } from './base';
 import { activatePopup } from './infoPopupModule';
-import { providerLogos, unicodeToString } from './helper';
+import { providerLogos, unicodeToString, removeLoadMoreButton } from './helper';
 // eslint-disable-next-line import/no-cycle
 import { removeOldSearchResults, removeLoaderAnimation, checkInternetConnection } from './searchModule';
 import { addSpinner, removeSpinner } from './spinner';
@@ -251,6 +251,7 @@ document.addEventListener('DOMContentLoaded', () => {
     elements.primarySection.style.display = 'block';
     elements.bookmarksSection.style.display = 'none';
     elements.showBookmarksIcon.style.display = 'inline-block';
+    removeLoadMoreButton(elements.loadMoreButtonWrapper);
     e.target.style.display = 'none';
 
     removeBookmarkImages();

--- a/src/popup/bookmarkModule.js
+++ b/src/popup/bookmarkModule.js
@@ -234,7 +234,7 @@ document.addEventListener('DOMContentLoaded', () => {
     elements.showBookmarksIcon.style.display = 'none';
     elements.inputField.value = '';
     checkInternetConnection();
-    addSpinner(elements.spinnerPlaceholderBookmarks);
+    addSpinner(elements.spinnerPlaceholderBookmarks, 'original');
     removeOldSearchResults();
     removeLoaderAnimation();
     restoreInitialContent('primary');

--- a/src/popup/helper.js
+++ b/src/popup/helper.js
@@ -142,3 +142,11 @@ export function makeElementsDisplayNone(elemArray) {
     e.style.display = 'none';
   });
 }
+
+export function addLoadMoreButton(loadMoreButtonPlaceholder) {
+  loadMoreButtonPlaceholder.classList.remove('display-none');
+}
+
+export function removeLoadMoreButton(loadMoreButtonPlaceholder) {
+  loadMoreButtonPlaceholder.classList.add('display-none');
+}

--- a/src/popup/infoPopupModule.js
+++ b/src/popup/infoPopupModule.js
@@ -218,7 +218,7 @@ function getImageData(imageId) {
 export function activatePopup(imageThumbnail) {
   elements.popup.style.opacity = 1;
   elements.popup.style.visibility = 'visible';
-  addSpinner(elements.spinnerPlaceholderPopup);
+  addSpinner(elements.spinnerPlaceholderPopup, 'original');
   getImageData(imageThumbnail.id);
   attributionTabLink.click();
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -87,6 +87,11 @@
               <div class="gutter-sizer"></div>
             </div>
           </div>
+          <div class="load-more-button-wrapper display-none">
+            <button class="load-more-button vocab button blue-colored small-sized">
+              <div class="content">Load more</div>
+            </button>
+          </div>
           <div id="spinner-placeholder--grid"></div>
           <p class="no-more-images-mes display-none">No more images!</p>
         </section>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -16,6 +16,7 @@ import {
   useCaseAPIQueryStrings,
   makeElementsDisplayNone,
   removeClassFromElements,
+  removeLoadMoreButton,
 } from './helper';
 import { loadProvidersToDom, resetLicenseDropDown, loadUserDefaults } from './filterModule';
 import { handleImageAttributionDownload, handleImageDownload } from './infoPopupModule';
@@ -275,8 +276,6 @@ $('#choose-license').comboTree({
 });
 loadUserDefaults();
 
-let processing;
-
 async function nextRequest(page) {
   const url = getRequestUrl(
     inputText,
@@ -293,28 +292,15 @@ async function nextRequest(page) {
   // console.log(result);
   addThumbnailsToDOM(result);
   pageNo += 1;
-  processing = false;
 }
 
 // global varialbe to check the status if user is viewwing the bookmarks section
 window.isBookmarksActive = false;
 
-// Trigger nextRequest when we reach bottom of the page
-// credit: https://stackoverflow.com/a/10662576/10425980
-$(document).ready(() => {
-  $(document).scroll(() => {
-    if (processing) return false;
-
-    if (
-      $(window).scrollTop() >= $(document).height() - $(window).height() - 700
-      && !window.isBookmarksActive
-    ) {
-      processing = true;
-
-      nextRequest(pageNo);
-    }
-    return undefined;
-  });
+elements.loadMoreButton.addEventListener('click', () => {
+  removeLoadMoreButton(elements.loadMoreButtonWrapper);
+  addSpinner(elements.spinnerPlaceholderGrid, 'for-bottom');
+  nextRequest(pageNo);
 });
 
 document.getElementById('settings-icon').addEventListener('click', () => {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -238,7 +238,7 @@ elements.searchIcon.addEventListener('click', () => {
   applyFilters();
 
   // enable spinner
-  addSpinner(elements.spinnerPlaceholderGrid);
+  addSpinner(elements.spinnerPlaceholderGrid, 'original');
   // elements.spinner.classList.add('spinner');
 
   const url = getRequestUrl(

--- a/src/popup/sass/components/_spinner.scss
+++ b/src/popup/sass/components/_spinner.scss
@@ -1,7 +1,12 @@
 // // credit: https://github.com/tobiasahlin/SpinKit
-.spinner {
-  margin: 6.50rem auto;
+.spinner-original {
+  margin: 4.50rem auto;
   width: 4.3rem;
+  text-align: center;
+}
+
+.spinner-for-bottom {
+  margin: 0 auto 4rem auto;
   text-align: center;
 }
 

--- a/src/popup/sass/layout/_search.scss
+++ b/src/popup/sass/layout/_search.scss
@@ -90,10 +90,17 @@
       display: inline-block;
       margin: 0.7rem 1rem 0rem;
     }
-  
+
     &--apply-filter-container {
       display: inline-block;
       margin: 0.7rem 1rem 0rem;
     }
+  }
+}
+
+.load-more-button {
+  &-wrapper {
+    margin-bottom: 6rem; // vertical height is increasing
+    text-align: center;
   }
 }

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -1,5 +1,5 @@
 import { elements } from './base';
-import { unicodeToString, providerLogos } from './helper';
+import { unicodeToString, providerLogos, addLoadMoreButton } from './helper';
 import { activatePopup } from './infoPopupModule';
 import { removeSpinner } from './spinner';
 // eslint-disable-next-line import/no-cycle

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -66,9 +66,17 @@ function showNoResultFoundMessage() {
   }
 }
 
+export function removeLoaderAnimation() {
+  // elements.spinner.classList.remove('spinner');
+  removeSpinner(elements.spinnerPlaceholderGrid);
+  // TODO: use better logic
+  // elements.noMoreImagesMessage.classList.remove('display-none');
+}
+
 export function checkResultLength(resultArray) {
   if (resultArray.length === 0) {
     showNoResultFoundMessage();
+    removeLoaderAnimation();
     // eslint-disable-next-line no-use-before-define
     msnry.layout();
   }
@@ -82,13 +90,8 @@ function appendToGrid(msnry, fragment, divs, grid) {
     // layout Masonry after each image loads
     msnry.layout();
   });
-}
-
-export function removeLoaderAnimation() {
-  // elements.spinner.classList.remove('spinner');
-  removeSpinner(elements.spinnerPlaceholderGrid);
-  // TODO: use better logic
-  // elements.noMoreImagesMessage.classList.remove('display-none');
+  removeLoaderAnimation();
+  addLoadMoreButton(elements.loadMoreButtonWrapper);
 }
 
 // TODO: be more specific

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -238,9 +238,5 @@ export function addThumbnailsToDOM(resultArray) {
     });
 
     appendToGrid(msnry, fragment, divs, elements.gridPrimary);
-
-    if (resultArray.length <= 10) {
-      removeLoaderAnimation();
-    }
   });
 }

--- a/src/popup/spinner.js
+++ b/src/popup/spinner.js
@@ -1,14 +1,22 @@
-export function getSpinnerMarkup() {
-  return `<div class="spinner">
-  <div class="bounce1"></div>
-  <div class="bounce2"></div>
-  <div class="bounce3"></div>
-</div>
-`;
+export function getSpinnerMarkup(context) {
+  if (context === 'for-bottom') {
+    return `<div class="spinner spinner-for-bottom">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
+  </div>`;
+  }
+  // if context != 'for-bottom' (==original)
+  return `<div class="spinner spinner-original">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
+  </div>`;
 }
 
-export function addSpinner(spinnerPlaceholder) {
-  spinnerPlaceholder.insertAdjacentHTML('afterbegin', getSpinnerMarkup());
+
+export function addSpinner(spinnerPlaceholder, context) {
+  spinnerPlaceholder.insertAdjacentHTML('afterbegin', getSpinnerMarkup(context));
 }
 
 export function removeSpinner(spinnerPlaceholder) {

--- a/tests/spinner.test.js
+++ b/tests/spinner.test.js
@@ -1,12 +1,19 @@
 import { getSpinnerMarkup } from '../src/popup/spinner';
 
 test('Checking spinner markup', () => {
-  const spinnerMarkup = getSpinnerMarkup();
+  const spinnerMarkupForBottom = getSpinnerMarkup('for-bottom');
 
-  expect(spinnerMarkup).toBe(`<div class="spinner">
-  <div class="bounce1"></div>
-  <div class="bounce2"></div>
-  <div class="bounce3"></div>
-</div>
-`);
+  expect(spinnerMarkupForBottom).toBe(`<div class="spinner spinner-for-bottom">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
+  </div>`);
+
+  const spinnerMarkupOriginal = getSpinnerMarkup('original');
+
+  expect(spinnerMarkupOriginal).toBe(`<div class="spinner spinner-original">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
+  </div>`);
 });


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #89 

**Description**
- show a load more button at the bottom of every batch of images that the user can click to load more images. 
- makes the process more predictable and stable.
- The spinner (loading animation) is made to do behave differently in two different situations (less margin when used with load-more button and original behavior in other cases like bookmarks loading and information loading in info popup). The tests for the spinner component are also updated.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

