### PR TITLE
bump the version to sync with extension stores

### DIFF
--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "name": "CC Search Browser Extension",
   "author": "Creative Commons",
   "description": "Search and filter images in the public domain and under Creative Commons licenses.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "manifest_version": 2,
   "icons": {
     "16": "icons/cc16.png",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "name": "CC Search Browser Extension",
   "author": "Creative Commons",
   "description": "Search and filter images in the public domain and under Creative Commons licenses.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "manifest_version": 2,
   "icons": {
     "16": "icons/cc16.png",

--- a/src/manifest.opera.json
+++ b/src/manifest.opera.json
@@ -2,7 +2,7 @@
   "name": "CC Search Browser Extension",
   "author": "Creative Commons",
   "description": "Search and filter images in the public domain and under Creative Commons licenses.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "manifest_version": 2,
   "icons": {
     "16": "icons/cc16.png",


### PR DESCRIPTION
A version was pushed to the extension stores for the FAQ page. This commit syncs the version number in the repositories with them.
You can check the [release](https://github.com/creativecommons/ccsearch-browser-extension/releases/tag/v1.2.4) on GitHub.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

