### PR TITLE
Use appendChild instead of addAdjacentNode for adding spinner

### DIFF
--- a/src/popup/spinner.js
+++ b/src/popup/spinner.js
@@ -1,22 +1,21 @@
 export function getSpinnerDiv(context) {
-  let divWrapper = document.createElement('div');
+  const divWrapper = document.createElement('div');
   divWrapper.classList.add('spinner');
 
   if (context === 'for-bottom') {
     divWrapper.classList.add('spinner-for-bottom');
-  }
-  else {
+  } else {
     // if context != 'for-bottom' (==original)
     divWrapper.classList.add('spinner-original');
   }
 
-  for (let i = 1; i <= 3; i++) {
-    let divBounce = document.createElement('div');
+  for (let i = 1; i <= 3; i += 1) {
+    const divBounce = document.createElement('div');
     divBounce.classList.add(`bounce${i}`);
     divWrapper.appendChild(divBounce);
   }
 
-  return divWrapper
+  return divWrapper;
 }
 
 

--- a/src/popup/spinner.js
+++ b/src/popup/spinner.js
@@ -1,22 +1,27 @@
-export function getSpinnerMarkup(context) {
+export function getSpinnerDiv(context) {
+  let divWrapper = document.createElement('div');
+  divWrapper.classList.add('spinner');
+
   if (context === 'for-bottom') {
-    return `<div class="spinner spinner-for-bottom">
-    <div class="bounce1"></div>
-    <div class="bounce2"></div>
-    <div class="bounce3"></div>
-  </div>`;
+    divWrapper.classList.add('spinner-for-bottom');
   }
-  // if context != 'for-bottom' (==original)
-  return `<div class="spinner spinner-original">
-    <div class="bounce1"></div>
-    <div class="bounce2"></div>
-    <div class="bounce3"></div>
-  </div>`;
+  else {
+    // if context != 'for-bottom' (==original)
+    divWrapper.classList.add('spinner-original');
+  }
+
+  for (let i = 1; i <= 3; i++) {
+    let divBounce = document.createElement('div');
+    divBounce.classList.add(`bounce${i}`);
+    divWrapper.appendChild(divBounce);
+  }
+
+  return divWrapper
 }
 
 
 export function addSpinner(spinnerPlaceholder, context) {
-  spinnerPlaceholder.insertAdjacentHTML('afterbegin', getSpinnerMarkup(context));
+  spinnerPlaceholder.appendChild(getSpinnerDiv(context));
 }
 
 export function removeSpinner(spinnerPlaceholder) {

--- a/tests/spinner.test.js
+++ b/tests/spinner.test.js
@@ -1,19 +1,22 @@
-import { getSpinnerMarkup } from '../src/popup/spinner';
+import { getSpinnerDiv } from '../src/popup/spinner';
 
 test('Checking spinner markup', () => {
-  const spinnerMarkupForBottom = getSpinnerMarkup('for-bottom');
+  const spinnerMarkupForBottom = getSpinnerDiv('for-bottom');
 
-  expect(spinnerMarkupForBottom).toBe(`<div class="spinner spinner-for-bottom">
-    <div class="bounce1"></div>
-    <div class="bounce2"></div>
-    <div class="bounce3"></div>
-  </div>`);
+  expect(spinnerMarkupForBottom.classList).toContain('spinner')
+  expect(spinnerMarkupForBottom.classList).toContain('spinner-for-bottom')
+  expect(spinnerMarkupForBottom.childElementCount).toBe(3)
+  let spinnerForBottomChildNodes = spinnerMarkupForBottom.childNodes
+  for (let i = 0; i < 3; i++) {
+    expect(spinnerForBottomChildNodes[i].classList).toContain(`bounce${i + 1}`);
+  }
 
-  const spinnerMarkupOriginal = getSpinnerMarkup('original');
-
-  expect(spinnerMarkupOriginal).toBe(`<div class="spinner spinner-original">
-    <div class="bounce1"></div>
-    <div class="bounce2"></div>
-    <div class="bounce3"></div>
-  </div>`);
+  const spinnerMarkupOriginal = getSpinnerDiv('original');
+  expect(spinnerMarkupOriginal.classList).toContain('spinner')
+  expect(spinnerMarkupOriginal.classList).toContain('spinner-original')
+  expect(spinnerMarkupOriginal.childElementCount).toBe(3)
+  let spinnerOriginalChildNodes = spinnerMarkupOriginal.childNodes
+  for (let i = 0; i < 3; i++) {
+    expect(spinnerOriginalChildNodes[i].classList).toContain(`bounce${i + 1}`);
+  }
 });


### PR DESCRIPTION
Firefox would give a warning for using addAdacentNode due to its performance
and security issues. Therefore the logic for getSpinnerMarkup was changed to
use DOM nodes instead of plain string markup. The tests were also updated for
the same.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

