### PR TITLE
Feat: Search retains even after closing popup

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -288,12 +288,11 @@ $('#choose-license').comboTree({
 });
 loadUserDefaults();
 
-async function loadStoredSearch() {
+function loadStoredSearch() {
   if (localStorage !== null) {
-    inputText = localStorage.getItem('title') ? localStorage.getItem('title') : '';
+    inputText = localStorage.getItem('title');
     elements.inputField.value = inputText;
 
-    storeSearch.pageNo = localStorage.getItem('pageNo');
     pageNo = 1;
     if (localStorage.getItem(pageNo)) {
       removeNode('primary__initial-info');
@@ -335,6 +334,8 @@ async function nextRequest(page) {
 
 // global varialbe to check the status if user is viewwing the bookmarks section
 window.isBookmarksActive = false;
+
+elements.homeIcon.addEventListener('click', loadStoredSearch);
 
 elements.loadMoreButton.addEventListener('click', () => {
   removeLoadMoreButton(elements.loadMoreButtonWrapper);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -306,18 +306,28 @@ async function loadStoredSearch() {
 loadStoredSearch();
 
 async function nextRequest(page) {
-  const url = getRequestUrl(
-    inputText,
-    userSelectedUseCaseList,
-    userSelectedLicensesList,
-    userSelectedProvidersList,
-    page,
-  );
+  let result = [];
 
-  // console.log(url);
-  const response = await fetch(url);
-  const json = await response.json();
-  const result = json.results;
+  if (localStorage.getItem(pageNo)) {
+    result = Object.values(JSON.parse(localStorage.getItem(pageNo)));
+  } else {
+    const url = getRequestUrl(
+      inputText,
+      userSelectedUseCaseList,
+      userSelectedLicensesList,
+      userSelectedProvidersList,
+      page,
+    );
+
+    // console.log(url);
+    const response = await fetch(url);
+    const json = await response.json();
+    result = json.results;
+
+    // Update Local Storage Data
+    storeSearch.page = { ...result };
+    localStorage.setItem(pageNo, JSON.stringify(storeSearch.page));
+  }
   // console.log(result);
   addThumbnailsToDOM(result);
   pageNo += 1;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -38,6 +38,9 @@ let userSelectedUseCaseList = [];
 // object to map Provider display names to valid query names.
 let providerAPIQueryStrings = {};
 
+// Search Storage
+const storeSearch = {};
+
 // eslint-disable-next-line no-undef
 const clipboard = new ClipboardJS('.btn-copy');
 
@@ -236,6 +239,7 @@ elements.searchIcon.addEventListener('click', () => {
   removeOldSearchResults();
   removeLoaderAnimation();
   applyFilters();
+  localStorage.clear();
 
   // enable spinner
   addSpinner(elements.spinnerPlaceholderGrid, 'original');
@@ -250,7 +254,7 @@ elements.searchIcon.addEventListener('click', () => {
   );
 
   // console.log(url);
-  pageNo += 1;
+  // pageNo += 1;
 
   fetch(url)
     .then(data => data.json())
@@ -261,6 +265,14 @@ elements.searchIcon.addEventListener('click', () => {
 
       checkResultLength(resultArray);
       addThumbnailsToDOM(resultArray);
+
+      // Store Data to local storage
+      storeSearch.title = inputText;
+      storeSearch.page = { ...resultArray };
+      localStorage.setItem('title', storeSearch.title);
+      localStorage.setItem(pageNo, JSON.stringify(storeSearch.page));
+
+      pageNo += 1;
     });
 });
 
@@ -275,6 +287,23 @@ $('#choose-license').comboTree({
   isMultiple: true,
 });
 loadUserDefaults();
+
+async function loadStoredSearch() {
+  if (localStorage !== null) {
+    inputText = localStorage.getItem('title') ? localStorage.getItem('title') : '';
+    elements.inputField.value = inputText;
+
+    storeSearch.pageNo = localStorage.getItem('pageNo');
+    pageNo = 1;
+    if (localStorage.getItem(pageNo)) {
+      removeNode('primary__initial-info');
+      const pageData = Object.values(JSON.parse(localStorage.getItem(pageNo)));
+      addThumbnailsToDOM(pageData);
+      pageNo = Number(pageNo) + 1;
+    }
+  }
+}
+loadStoredSearch();
 
 async function nextRequest(page) {
   const url = getRequestUrl(


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #79

**Description**
<!-- Add your description below. -->
Implements search to retain,even if user closes the popup.

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->
1. Users need not search and load all the images again, if they close the popup by mistake, or to 
    check something else.
2. It will decrease number of requests made to the server, hence increasing performance.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

