### PR TITLE
fix #166: render the source icons over image thumbnails

### DIFF
--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -144,7 +144,7 @@ export function addThumbnailsToDOM(resultArray) {
     resultArray.forEach((element) => {
       const thumbnail = element.url; // element.thumbnail giving 403
       const title = unicodeToString(element.title);
-      const { license, provider, id } = element;
+      const { license, source, id } = element;
       const licenseArray = license.split('-'); // split license in individual characteristics
       const foreignLandingUrl = element.foreign_landing_url;
 
@@ -166,18 +166,18 @@ export function addThumbnailsToDOM(resultArray) {
       foreignLandingLinkElement.setAttribute('target', '_blank');
       foreignLandingLinkElement.setAttribute('class', 'foreign-landing-url');
 
-      const providerImageElement = document.createElement('img');
-      let providerLogoName;
+      const sourceImageElement = document.createElement('img');
+      let sourceLogoName;
       for (let i = 0; i < sourceLogos.length; i += 1) {
-        if (sourceLogos[i].includes(provider)) {
-          providerLogoName = sourceLogos[i];
+        if (sourceLogos[i].includes(source)) {
+          sourceLogoName = sourceLogos[i];
           break;
         }
       }
-      providerImageElement.setAttribute('src', `img/provider_logos/${providerLogoName}`);
-      providerImageElement.setAttribute('class', 'provider-image');
+      sourceImageElement.setAttribute('src', `img/provider_logos/${sourceLogoName}`);
+      sourceImageElement.setAttribute('class', 'provider-image');
 
-      foreignLandingLinkElement.appendChild(providerImageElement);
+      foreignLandingLinkElement.appendChild(sourceImageElement);
       foreignLandingLinkElement.appendChild(imageTitleNode);
 
       spanTitleElement.appendChild(foreignLandingLinkElement);


### PR DESCRIPTION
Fixes #166 

**Description**
Modify the code according to the new API schema to get the source name and therefore render the source icon properly.

**Before**
![](https://user-images.githubusercontent.com/34679965/75540763-ade48f00-5a42-11ea-8dad-53c8191efc4a.png)

**After**
![Screenshot from 2020-03-03 21-53-31](https://user-images.githubusercontent.com/34679965/75796738-1a8cc000-5d9a-11ea-8fd0-655dec190e49.png)

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

