### PR TITLE
fix #148: update the sample image object schema to the new API version

### DIFF
--- a/tests/infoPopupModule.test.js
+++ b/tests/infoPopupModule.test.js
@@ -13,27 +13,24 @@ const image = {
   tags: [
     {
       name: 'dog',
-      provider: 'flickr',
     },
     {
       name: 'happy',
-      provider: 'flickr',
     },
   ],
   url: 'https://farm5.staticflickr.com/4036/4696290733_5f8794441e_b.jpg',
   thumbnail: 'https://farm5.staticflickr.com/4036/4696290733_5f8794441e_m.jpg',
-  provider: 'Flickr',
   source: 'flickr',
   license: 'by-nc-nd',
   license_version: '2.0',
-  foreign_landing_url: 'https://www.flickr.com/photos/46586088@N05/4696290733',
-  meta_data: null,
-  view_count: 0,
-  provider_url: 'https://www.flickr.com',
   license_url: 'https://creativecommons.org/licenses/by-nc-nd/2.0/',
+  foreign_landing_url: 'https://www.flickr.com/photos/46586088@N05/4696290733',
+  detail_url: 'https://api.creativecommons.engineering/v1/images/bafff537-0c74-4fa6-9867-401e440e97f5',
+  related_url: 'https://api.creativecommons.engineering/v1/recommendations/images/bafff537-0c74-4fa6-9867-401e440e97f5',
+  height: 1000,
+  width: 667,
   attribution:
     '"Megi - Lutka Moja" by cipovic is licensed under CC-BY-NC-ND 2.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-nd/2.0/.',
-  provider_code: 'flickr',
 };
 
 // test('Testing getRichTextAttribution', () => {
@@ -52,7 +49,7 @@ test('Testing getHtmlAttribution', () => {
   expect(testHtmlAttribution).toBe(correctAttribution);
 });
 
-test('Testing getHtmlAttribution', () => {
+test('Testing getPlainAttribution', () => {
   const testPlainAttribution = getPlainAttribution(image);
 
   const correctAttribution = `"Megi - Lutka Moja" by cipovic is licensed under CC BY-NC-ND 2.0


### PR DESCRIPTION
Fixes #148 

**Description**
In InfoPopupModule.test.js, we have a sample image detail response object defined which is used in test functions. Its schema is updated to the new version.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

