### PR TITLE
fix #146: update fetchProviders() and getLatestProviders()

### DIFF
--- a/src/options/helper.js
+++ b/src/options/helper.js
@@ -1,5 +1,5 @@
 import elements from './base';
-import { showNotification, getLatestProviders } from '../utils';
+import { showNotification, getLatestSources } from '../utils';
 
 export function restoreFilters(inputElements) {
   for (let i = 0; i < inputElements.length; i += 1) {
@@ -42,7 +42,7 @@ function addProvidersToDom(providers) {
 export async function init() {
   restoreFilters(elements.useCaseInputs);
   restoreFilters(elements.licenseInputs);
-  const providers = await getLatestProviders();
+  const providers = await getLatestSources();
   addProvidersToDom(providers);
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -24,7 +24,7 @@ import { addSpinner } from './spinner';
 import {
   showNotification,
   removeNode,
-  getLatestProviders,
+  getLatestSources,
   restoreInitialContent,
 } from '../utils';
 
@@ -100,7 +100,7 @@ elements.inputField.addEventListener('keydown', (event) => {
 });
 
 async function populateProviderList() {
-  providerAPIQueryStrings = await getLatestProviders();
+  providerAPIQueryStrings = await getLatestSources();
 
   let count = 0;
   const providersList = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,26 +55,26 @@ export function restoreInitialContent(context) {
   }
 }
 
-export async function fetchProviders() {
-  const getProviderURL = 'https://api.creativecommons.engineering/statistics/image';
-  const data = await fetch(getProviderURL);
+export async function fetchSources() {
+  const getSourceURL = 'https://api.creativecommons.engineering/v1/sources';
+  const data = await fetch(getSourceURL);
   // console.log(data);
 
   return data.json();
 }
 
-export async function getLatestProviders() {
-  let providers = {};
+export async function getLatestSources() {
+  let sources = {};
   try {
-    const result = await fetchProviders();
-    result.forEach((provider) => {
-      providers[provider.display_name] = provider.provider_name;
+    const result = await fetchSources();
+    result.forEach((source) => {
+      sources[source.display_name] = source.source_name;
     });
-    return providers;
+    return sources;
   } catch (error) {
-    showNotification('Unable to fetch providers. Using backup providers', 'negative', 'snackbar-bookmarks', 2500);
-    providers = backupProviderAPIQueryStrings;
-    return providers;
+    showNotification('Unable to fetch sources. Using backup sources', 'negative', 'snackbar-bookmarks', 2500);
+    sources = backupProviderAPIQueryStrings;
+    return sources;
   }
 }
 


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #146 

**Description**
Update fetchProviders() and getLatestProviders() :
- Update the api url from https://api.creativecommons.engineering/statistics/image to https://api.creativecommons.engineering/v1/sources
- Use the new API terminology (source instead of provider) in variables, function names, object names etc. 
- Change `getLatestProviders()` -> `getLatestSources()` everywhere in the code.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

