### PR TITLE
Move utils from bookmarkModule.js to bookmarkModule.utils.js

### DIFF
--- a/src/popup/bookmarkModule.js
+++ b/src/popup/bookmarkModule.js
@@ -1,6 +1,6 @@
 import { elements } from './base';
 import { activatePopup } from './infoPopupModule';
-import { msnry, removeBookmarkImages } from './bookmarkModule.utils';
+import { msnry, removeBookmarkImages, removeBookmark } from './bookmarkModule.utils';
 import { sourceLogos, unicodeToString, removeLoadMoreButton } from './helper';
 // eslint-disable-next-line import/no-cycle
 import { removeOldSearchResults, removeLoaderAnimation, checkInternetConnection } from './searchModule';
@@ -14,58 +14,6 @@ const bookmarkDOM = {};
 
 // Store number of selected bookmarks for export
 let selectedBookmarks = 0;
-
-export default function toggleBookmark(e) {
-  chrome.storage.sync.get({ bookmarks: [] }, items => {
-    const bookmarksArray = items.bookmarks;
-    const imageId = e.target.dataset.imageid;
-    if (bookmarksArray.indexOf(imageId) === -1) {
-      bookmarksArray.push(imageId);
-      chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
-        e.target.classList.remove('fa-bookmark-o');
-        e.target.classList.add('fa-bookmark');
-        e.target.title = 'Remove Bookmark';
-        showNotification('Image Bookmarked', 'positive', 'snackbar-bookmarks');
-      });
-    } else {
-      const bookmarkIndex = bookmarksArray.indexOf(imageId);
-      bookmarksArray.splice(bookmarkIndex, 1);
-      chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
-        e.target.classList.remove('fa-bookmark');
-        e.target.classList.add('fa-bookmark-o');
-        e.target.title = 'Bookmark Image';
-        showNotification('Bookmark removed', 'negative', 'snackbar-bookmarks');
-      });
-    }
-  });
-}
-
-function removeBookmark(e) {
-  const imageId = e.target.dataset.imageid;
-  chrome.storage.sync.get({ bookmarks: [] }, items => {
-    const bookmarksArray = items.bookmarks;
-
-    const bookmarkIndex = bookmarksArray.indexOf(imageId);
-    bookmarksArray.splice(bookmarkIndex, 1);
-
-    let isLastImage = false;
-    if (bookmarksArray.length === 0) {
-      isLastImage = true;
-    }
-
-    chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
-      const imageDiv = document.getElementById(`id_${imageId}`);
-      imageDiv.parentElement.removeChild(imageDiv);
-      // eslint-disable-next-line no-use-before-define
-      msnry.layout(); // layout grid again
-      showNotification('Bookmark removed', 'positive', 'snackbar-bookmarks');
-
-      if (isLastImage) {
-        restoreInitialContent('bookmarks');
-      }
-    });
-  });
-}
 
 function appendToGrid(msnryObject, fragment, e, grid) {
   grid.appendChild(fragment);
@@ -261,8 +209,7 @@ function loadImages() {
   });
 }
 
-// TODO: use a general function
-
+// EventListeners
 document.addEventListener('DOMContentLoaded', () => {
   elements.showBookmarksIcon.addEventListener('click', () => {
     window.isBookmarksActive = true;

--- a/src/popup/bookmarkModule.utils.js
+++ b/src/popup/bookmarkModule.utils.js
@@ -1,5 +1,5 @@
 import { elements } from './base';
-import { removeChildNodes } from '../utils';
+import { showNotification, removeChildNodes, restoreInitialContent } from '../utils';
 
 const Masonry = require('masonry-layout');
 
@@ -17,4 +17,56 @@ export function removeBookmarkImages() {
   div.classList.add('gutter-sizer');
   removeChildNodes(elements.gridBookmarks);
   elements.gridBookmarks.appendChild(div);
+}
+
+export default function toggleBookmark(e) {
+  chrome.storage.sync.get({ bookmarks: [] }, items => {
+    const bookmarksArray = items.bookmarks;
+    const imageId = e.target.dataset.imageid;
+    if (bookmarksArray.indexOf(imageId) === -1) {
+      bookmarksArray.push(imageId);
+      chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
+        e.target.classList.remove('fa-bookmark-o');
+        e.target.classList.add('fa-bookmark');
+        e.target.title = 'Remove Bookmark';
+        showNotification('Image Bookmarked', 'positive', 'snackbar-bookmarks');
+      });
+    } else {
+      const bookmarkIndex = bookmarksArray.indexOf(imageId);
+      bookmarksArray.splice(bookmarkIndex, 1);
+      chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
+        e.target.classList.remove('fa-bookmark');
+        e.target.classList.add('fa-bookmark-o');
+        e.target.title = 'Bookmark Image';
+        showNotification('Bookmark removed', 'negative', 'snackbar-bookmarks');
+      });
+    }
+  });
+}
+
+export function removeBookmark(e) {
+  const imageId = e.target.dataset.imageid;
+  chrome.storage.sync.get({ bookmarks: [] }, items => {
+    const bookmarksArray = items.bookmarks;
+
+    const bookmarkIndex = bookmarksArray.indexOf(imageId);
+    bookmarksArray.splice(bookmarkIndex, 1);
+
+    let isLastImage = false;
+    if (bookmarksArray.length === 0) {
+      isLastImage = true;
+    }
+
+    chrome.storage.sync.set({ bookmarks: bookmarksArray }, () => {
+      const imageDiv = document.getElementById(`id_${imageId}`);
+      imageDiv.parentElement.removeChild(imageDiv);
+      // eslint-disable-next-line no-use-before-define
+      msnry.layout(); // layout grid again
+      showNotification('Bookmark removed', 'positive', 'snackbar-bookmarks');
+
+      if (isLastImage) {
+        restoreInitialContent('bookmarks');
+      }
+    });
+  });
 }

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -3,7 +3,7 @@ import { unicodeToString, sourceLogos, addLoadMoreButton, removeLoadMoreButton }
 import { activatePopup } from './infoPopupModule';
 import { removeSpinner } from './spinner';
 // eslint-disable-next-line import/no-cycle
-import toggleBookmark from './bookmarkModule';
+import toggleBookmark from './bookmarkModule.utils';
 import { showNotification, removeChildNodes, restoreInitialContent } from '../utils';
 
 const Masonry = require('masonry-layout');


### PR DESCRIPTION
Fixes #141

**Description**
Move the rest of the utils from `bookmarkModule.js` to `bookmarksModule.utils.js`.

**Other information**
For the list of functions and objects transferred, refer to the [issue](https://github.com/creativecommons/ccsearch-browser-extension/issues/141) descriptions.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

