### PR TITLE
Use the values in local Storage to set the checkboxes of "Other Settings" tab

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -2,9 +2,6 @@ import elements from './base';
 import { init, saveFiltersOptions, updateBookmarks, toggleAccordion } from './helper';
 import { showNotification } from '../utils';
 
-let enableSearchStorageOption = true;
-let enableSearchClearConfirmOption = false;
-
 document.addEventListener('DOMContentLoaded', init);
 
 elements.saveFiltersButton.addEventListener('click', saveFiltersOptions);
@@ -32,14 +29,6 @@ Array.prototype.forEach.call(elements.licenseInputs, element => {
   });
 });
 
-function initEnableSearchStorageButton() {
-  chrome.storage.sync.get(['enableSearchStorage'], res => {
-    enableSearchStorageOption = res.enableSearchStorage;
-    elements.enableSearchStorageCheckbox.checked = enableSearchStorageOption;
-  });
-}
-initEnableSearchStorageButton();
-
 elements.enableSearchStorageCheckbox.addEventListener('click', () => {
   chrome.storage.sync.set({ enableSearchStorage: elements.enableSearchStorageCheckbox.checked }, () => {
     showNotification('Settings Saved', 'positive', 'snackbar-options');
@@ -49,13 +38,17 @@ elements.enableSearchStorageCheckbox.addEventListener('click', () => {
   if (!elements.enableSearchStorageCheckbox.checked) localStorage.clear();
 });
 
-function initEnableSearchClearConfirmButton() {
+// Mark the checkboxes in the "Other Settings" tab according to the local storage values
+function initOtherSettingsCheckboxes() {
+  chrome.storage.sync.get(['enableSearchStorage'], res => {
+    elements.enableSearchStorageCheckbox.checked = res.enableSearchStorage;
+  });
   chrome.storage.sync.get(['enableSearchClearConfirm'], res => {
-    enableSearchClearConfirmOption = res.enableSearchClearConfirm;
-    elements.enableSearchClearConfirmCheckbox.checked = enableSearchClearConfirmOption;
+    elements.enableSearchClearConfirmCheckbox.checked = res.enableSearchClearConfirm;
   });
 }
-initEnableSearchClearConfirmButton();
+
+initOtherSettingsCheckboxes();
 
 elements.enableSearchClearConfirmCheckbox.addEventListener('click', () => {
   chrome.storage.sync.set(

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -322,6 +322,7 @@ loadUserDefaults();
 
 function setEnableSearchStorageOptionVariable(enableSearchStorage) {
   if (enableSearchStorage === undefined) {
+    // enable the feature by default (on startup, enableSearchStorage key will by undefined)
     enableSearchStorageOption = true;
     chrome.storage.sync.set({ enableSearchStorage: enableSearchStorageOption });
   } else enableSearchStorageOption = enableSearchStorage;


### PR DESCRIPTION
**Description**

Instead of using individual variables for storing the stateof the feature checkboxes, use the key values stored inlocal storage. If the values are not set, it returs undefined which is already a falsy.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

