### PR TITLE
logically break getRichTextAttribution into two functions

### DIFF
--- a/src/popup/infoPopupModule.js
+++ b/src/popup/infoPopupModule.js
@@ -4,8 +4,7 @@ import { removeChildNodes } from '../utils';
 
 const download = require('downloadjs');
 
-// eslint-disable-next-line consistent-return
-export function getRichTextAttribution(image, targetNode) {
+export function getRichTextAttribution(image) {
   if (!image) {
     return '';
   }
@@ -20,10 +19,13 @@ export function getRichTextAttribution(image, targetNode) {
     image.license_url
   }" target="_blank">CC ${image.license.toUpperCase()} ${image.license_version}</a>`;
 
-  // return `${imgLink}${creator}${licenseLink}`;
-  const final = `<div>${imgLink}${creator}${licenseLink}</div>`;
+  return `${imgLink}${creator}${licenseLink}`;
+}
+
+function embedRichTextAttribution(image, targetNode) {
+  const richTextAttribution = `<div>${getRichTextAttribution(image)}</div>`;
   const parser = new DOMParser();
-  const parsed = parser.parseFromString(final, 'text/html');
+  const parsed = parser.parseFromString(richTextAttribution, 'text/html');
   const tags = parsed.getElementsByTagName('div');
   targetNode.appendChild(tags[0]);
 }
@@ -196,9 +198,8 @@ function getImageData(imageId) {
       popupSource.appendChild(getPopupSourceChildNode(foreignLandingUrl, source));
       removeChildNodes(popupLicense);
       popupLicense.appendChild(getPopupLicenseChildNode(licenseUrl, license.toUpperCase()));
-      // attributionRichTextPara.textContent = getRichTextAttribution(res, attributionRichTextPara);
       removeChildNodes(attributionRichTextPara);
-      getRichTextAttribution(res, attributionRichTextPara);
+      embedRichTextAttribution(res, attributionRichTextPara);
       attributionHtmlTextArea.value = getHtmlAttribution(res);
       elements.downloadImageButton.addEventListener('click', handleImageDownload);
       elements.downloadImageAttributionButton.addEventListener('click', handleImageAttributionDownload);


### PR DESCRIPTION
**Description**
`getRichTextAttribution` -> `getRichTextAttribution` and `embedRichTextAttribution`.
The former is called during the execution of the latter. 

**Other Informations**
This would help us to reintroduce the test for the `getRichTextAttribution` function.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

