### PR TITLE
Don't overwrite the cache by empty result

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -237,7 +237,6 @@ elements.searchIcon.addEventListener('click', () => {
   removeOldSearchResults();
   removeLoaderAnimation();
   applyFilters();
-  localStorage.clear();
 
   // enable spinner
   addSpinner(elements.spinnerPlaceholderGrid, 'original');
@@ -259,13 +258,13 @@ elements.searchIcon.addEventListener('click', () => {
     .then(res => {
       checkValidationError(res);
       const resultArray = res.results;
-      // console.log(resultArray);
 
       checkResultLength(resultArray);
       addThumbnailsToDOM(resultArray);
 
-      if (enableSearchStorageOption) {
-        // Store Data to local storage
+      // Store Data to local storage
+      if (enableSearchStorageOption && resultArray.length !== 0) {
+        localStorage.clear(); // clear the old results
         storeSearch.title = inputText;
         storeSearch.page = { ...resultArray };
         localStorage.setItem('title', storeSearch.title);
@@ -276,12 +275,15 @@ elements.searchIcon.addEventListener('click', () => {
     });
   elements.clearSearchButton[0].classList.remove('display-none');
 });
+
 elements.modal.addEventListener('click', () => {
   elements.modalCancel.click();
 });
+
 elements.modalBody.addEventListener('click', e => {
   e.stopPropagation();
 });
+
 elements.clearSearchButton[0].addEventListener('click', () => {
   const modalText = 'Do you really want to clear the search?';
   function onModalConfirm() {


### PR DESCRIPTION
Fixes #217 

**Description**
Don't overwrite the search data stored in localStorage if the user search query gives an empty result. Out of the two possible alternatives described in the issue, I have chosen to show the previous search results instead of the welcome screen.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

