### PR TITLE
Improve UI and accessibility of filter section in firefox

### DIFF
--- a/src/popup/sass/components/_darkmode.scss
+++ b/src/popup/sass/components/_darkmode.scss
@@ -31,6 +31,11 @@ body.dark {
     color: $color-white !important;
   }
 
+  // dropdown arrow icon
+  .comboTreeArrowBtnImg {
+    color: white;
+  }
+
   #search-icon {
     color: $color-white;
   }

--- a/src/popup/vendors/css/comboTreestyle.css
+++ b/src/popup/vendors/css/comboTreestyle.css
@@ -6,14 +6,12 @@
   position: relative;
 }
 .comboTreeArrowBtn {
-  position: absolute;
-  right: 4px;
-  bottom: 1px;
-  top: 1px;
   cursor: pointer;
   background-color: transparent;
   box-sizing: border-box;
   border: none;
+  height: 0;
+  width: 0;
 }
 .comboTreeDropDownContainer {
   display: none;
@@ -67,7 +65,7 @@ span.comboTreeItemTitle {
   float: left;
 }
 .comboTreeInputBox {
-  padding: 6px;
+  padding: 0.25rem;
   width: 100%;
   border: 1px solid black;
   box-sizing: border-box;
@@ -78,10 +76,17 @@ span.comboTreeItemTitle {
   cursor: pointer;
   color: transparent;
   text-shadow: 0 0 0 #2196f3;
+  font-size: 0.9rem;
 }
 .comboTreeInputBox::placeholder {
   color: black;
+  font-size: 0.9rem;
+  opacity: 1;
 }
 .comboTreeArrowBtnImg {
+  position: absolute;
   font-size: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0.4rem;
 }


### PR DESCRIPTION
Fixes #219 

**Description**
Changing absolute sizing to relative and absolute positioning the arrow icon instead of the button did the trick. The button was rendering differently in firefox and chrome and therefore rules rendering in one browser were not rendering the same way in the other.

**Screenshots**

**Before**

![](https://user-images.githubusercontent.com/34679965/79364741-628d2e00-7f67-11ea-82ca-04984522ba7c.png)

**After**

![Screenshot from 2020-04-16 12-50-29](https://user-images.githubusercontent.com/34679965/79427233-ef74cd80-7fe1-11ea-9162-dc63b36fa7d2.png)

**Dark Mode Before**

![](https://user-images.githubusercontent.com/34679965/79364999-b0a23180-7f67-11ea-9982-55404b7caacf.png)

**Dark Mode After**

![Screenshot from 2020-04-16 12-50-36](https://user-images.githubusercontent.com/34679965/79427413-437fb200-7fe2-11ea-8f7c-d6b45bb4a927.png)


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

