### PR TITLE
Show "bookmark removed" message with positive context

### DIFF
--- a/src/popup/bookmarkModule.js
+++ b/src/popup/bookmarkModule.js
@@ -34,7 +34,7 @@ export default function toggleBookmark(e) {
         e.target.classList.remove('fa-bookmark');
         e.target.classList.add('fa-bookmark-o');
         e.target.title = 'Bookmark Image';
-        showNotification('Bookmark removed', 'negative', 'snackbar-bookmarks');
+        showNotification('Bookmark removed', 'positive', 'snackbar-bookmarks');
       });
     }
   });


### PR DESCRIPTION
**Description**
<!-- Add your description below. -->
Just like https://github.com/creativecommons/ccsearch-browser-extension/blob/master/src/popup/bookmarkModule.utils.js#L40, the context of the message "bookmark removed" must be positive in the search section. This PR does this minor change.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

