### PR TITLE
Store the filter information and the updated search in the cache

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -269,8 +269,6 @@ elements.searchIcon.addEventListener('click', () => {
 
       // Store Data to local storage
       if (resultArray.length !== 0) {
-        let filtercheck = true;
-
         localStorage.clear(); // clear the old results
         storeSearch.title = inputText;
         localStorage.setItem('usecaseDropdownValues', elements.useCaseChooser.value);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -206,6 +206,9 @@ function applyFilters() {
     });
   }
 
+  // console.log(elements.sourceChooser.value);
+  // console.log(userSelectedSourcesList);
+
   if (elements.licenseChooser.value) {
     const userInputLicensesList = elements.licenseChooser.value.split(', ');
     userInputLicensesList.forEach(element => {
@@ -266,10 +269,18 @@ elements.searchIcon.addEventListener('click', () => {
 
       // Store Data to local storage
       if (resultArray.length !== 0) {
+        let filtercheck = true;
+
+        localStorage.clear(); // clear the old results
         storeSearch.title = inputText;
+        localStorage.setItem('usecaseDropdownValues', elements.useCaseChooser.value);
+        localStorage.setItem('sourceDropdownValues', elements.sourceChooser.value);
+        localStorage.setItem('licenseDropdownValues', elements.licenseChooser.value);
         storeSearch.page = { ...resultArray };
         localStorage.setItem('title', storeSearch.title);
         localStorage.setItem(pageNo, JSON.stringify(storeSearch.page));
+
+        console.log(localStorage);
       }
 
       pageNo += 1;
@@ -335,6 +346,9 @@ async function loadStoredSearch() {
   if (localStorage.length !== 0) {
     inputText = localStorage.getItem('title');
     elements.inputField.value = inputText;
+    elements.sourceChooser.value = localStorage.getItem('sourceDropdownValues');
+    elements.useCaseChooser.value = localStorage.getItem('usecaseDropdownValues');
+    elements.licenseChooser.value = localStorage.getItem('licenseDropdownValues');
 
     pageNo = 1;
     if (localStorage.getItem(pageNo)) {
@@ -359,6 +373,10 @@ async function loadStoredSearchOnInit() {
       if (localStorage.length !== 0) {
         inputText = localStorage.getItem('title');
         elements.inputField.value = inputText;
+        // filling the dropdown values
+        elements.sourceChooser.value = localStorage.getItem('sourceDropdownValues');
+        elements.useCaseChooser.value = localStorage.getItem('usecaseDropdownValues');
+        elements.licenseChooser.value = localStorage.getItem('licenseDropdownValues');
 
         pageNo = 1;
         if (localStorage.getItem(pageNo)) {


### PR DESCRIPTION
Fixes #218 

**Description**
Add the information about the filters applied to the cache and show them in the dropdowns when it is loaded. Earlier, the search results that were being loaded from the cache didn't specify which filters were applied to get that result.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

