### PR TITLE
Change filter icon color when atleast one filter is activated

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -142,6 +142,9 @@ elements.filterResetButton.addEventListener('click', () => {
     }
   });
 
+  // the filter is not activated anymore
+  elements.filterIcon.classList.remove('activate-filter');
+
   // clear the datastructures and make a fresh search
   userSelectedLicensesList = [];
   userSelectedSourcesList = [];
@@ -206,9 +209,6 @@ function applyFilters() {
     });
   }
 
-  // console.log(elements.sourceChooser.value);
-  // console.log(userSelectedSourcesList);
-
   if (elements.licenseChooser.value) {
     const userInputLicensesList = elements.licenseChooser.value.split(', ');
     userInputLicensesList.forEach(element => {
@@ -221,6 +221,13 @@ function applyFilters() {
     userInputUseCaseList.forEach(element => {
       userSelectedUseCaseList.push(useCaseAPIQueryStrings[element]);
     });
+  }
+
+  // "activate" filter icon if some filters are applied
+  if (userSelectedSourcesList.length > 0 || userSelectedLicensesList.length > 0 || userSelectedUseCaseList.length > 0) {
+    elements.filterIcon.classList.add('activate-filter');
+  } else {
+    elements.filterIcon.classList.remove('activate-filter');
   }
 }
 
@@ -340,22 +347,26 @@ function setEnableSearchStorageOptionVariable(enableSearchStorage) {
   } else enableSearchStorageOption = enableSearchStorage;
 }
 
+function loadStoredContentToUI() {
+  inputText = localStorage.getItem('title');
+  elements.inputField.value = inputText;
+  elements.sourceChooser.value = localStorage.getItem('sourceDropdownValues');
+  elements.useCaseChooser.value = localStorage.getItem('usecaseDropdownValues');
+  elements.licenseChooser.value = localStorage.getItem('licenseDropdownValues');
+
+  pageNo = 1;
+  if (localStorage.getItem(pageNo)) {
+    removeNode('primary__initial-info');
+    const pageData = Object.values(JSON.parse(localStorage.getItem(pageNo)));
+    addThumbnailsToDOM(pageData);
+    pageNo = Number(pageNo) + 1;
+  }
+  elements.clearSearchButton[0].classList.remove('display-none');
+}
+
 async function loadStoredSearch() {
   if (localStorage.length !== 0) {
-    inputText = localStorage.getItem('title');
-    elements.inputField.value = inputText;
-    elements.sourceChooser.value = localStorage.getItem('sourceDropdownValues');
-    elements.useCaseChooser.value = localStorage.getItem('usecaseDropdownValues');
-    elements.licenseChooser.value = localStorage.getItem('licenseDropdownValues');
-
-    pageNo = 1;
-    if (localStorage.getItem(pageNo)) {
-      removeNode('primary__initial-info');
-      const pageData = Object.values(JSON.parse(localStorage.getItem(pageNo)));
-      addThumbnailsToDOM(pageData);
-      pageNo = Number(pageNo) + 1;
-    }
-    elements.clearSearchButton[0].classList.remove('display-none');
+    loadStoredContentToUI();
   } else {
     removeNode('no-image-found');
     restoreInitialContent('primary');
@@ -367,25 +378,11 @@ async function loadStoredSearchOnInit() {
   await chrome.storage.sync.get(['enableSearchStorage'], res => {
     setEnableSearchStorageOptionVariable(res.enableSearchStorage);
 
-    if (enableSearchStorageOption) {
-      if (localStorage.length !== 0) {
-        inputText = localStorage.getItem('title');
-        elements.inputField.value = inputText;
-        // filling the dropdown values
-        elements.sourceChooser.value = localStorage.getItem('sourceDropdownValues');
-        elements.useCaseChooser.value = localStorage.getItem('usecaseDropdownValues');
-        elements.licenseChooser.value = localStorage.getItem('licenseDropdownValues');
+    if (localStorage.length !== 0 && enableSearchStorageOption) {
+      loadStoredContentToUI();
 
-        pageNo = 1;
-        if (localStorage.getItem(pageNo)) {
-          removeNode('primary__initial-info');
-          const pageData = Object.values(JSON.parse(localStorage.getItem(pageNo)));
-          addThumbnailsToDOM(pageData);
-          pageNo = Number(pageNo) + 1;
-        }
-        elements.clearSearchButton[0].classList.remove('display-none');
-      } else {
-        elements.clearSearchButton[0].classList.add('display-none');
+      if (elements.sourceChooser.value || elements.useCaseChooser.value || elements.licenseChooser.value) {
+        elements.filterIcon.classList.add('activate-filter');
       }
     } else {
       elements.clearSearchButton[0].classList.add('display-none');

--- a/src/popup/sass/components/_darkmode.scss
+++ b/src/popup/sass/components/_darkmode.scss
@@ -44,6 +44,14 @@ body.dark {
     color: $color-white;
   }
 
+  #filter-icon.activate-filter {
+    color: $color-primary-light;
+
+    &:hover {
+      color: $color-primary-dark;
+    }
+  }
+
   .popup__tab-links {
     background-color: $color-darkmode-2;
     color: $color-white;

--- a/src/popup/sass/layout/_search.scss
+++ b/src/popup/sass/layout/_search.scss
@@ -35,12 +35,20 @@
       right: 10%;
     }
 
+    &.activate-filter {
+      color: $color-primary-light;
+
+      &:hover {
+        color: $color-primary-dark;
+      }
+    }
+
     &.clear-search-button {
-      color: #ff5b24;
+      color: $color-primary-light;
       right: 16%;
 
       &:hover {
-        color: #fb4102;
+        color: $color-primary-dark;
       }
     }
     &:hover {


### PR DESCRIPTION
Fixes #233

**Description**
When the user applies at least one of the filters, then the filter icon will change it's color to primary color(orange shade). This will give an indication to the users that some filters are applied and hence they don't need to open the filter section, again and again, to verify that.

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/34679965/80406980-84c96900-88e2-11ea-86dd-5690214035e2.gif)

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

