### PR TITLE
give precedence to last stored session over default filters (during clash)

### DIFF
--- a/src/popup/filterModule.js
+++ b/src/popup/filterModule.js
@@ -3,7 +3,7 @@ import { elements } from './base';
 // list to hold Sources to show to the user in dropdown
 // the list must have objects with id and title as properties.
 // see https://github.com/kirlisakal/combo-tree#sample-json-data
-function loadFilterSection(wrapperElement) {
+function loadFilterPreferences(wrapperElement) {
   const dropdownContainer = wrapperElement.querySelector('.comboTreeDropDownContainer');
   const inputCheckboxes = dropdownContainer.getElementsByTagName('input');
   // unchecking all the options
@@ -13,12 +13,13 @@ function loadFilterSection(wrapperElement) {
     chrome.storage.sync.get({ [id]: false }, items => {
       if (items[id]) {
         inputCheckboxes[i].click();
+        elements.filterIcon.classList.add('activate-filter');
       }
     });
   }
 }
 
-export function loadSourcesToDom(SourcesList) {
+export function loadSourcesToDom(SourcesList, loadingStoredSearch = false) {
   $('#choose-source').comboTree({
     source: SourcesList,
     isMultiple: true,
@@ -26,7 +27,10 @@ export function loadSourcesToDom(SourcesList) {
 
   elements.sourceChooserLoadingMessage.style.display = 'none';
   elements.sourceChooserWrapper.style.display = 'inline-block';
-  loadFilterSection(elements.sourceChooserWrapper);
+
+  if (!loadingStoredSearch) {
+    loadFilterPreferences(elements.sourceChooserWrapper);
+  }
 }
 
 export function resetLicenseDropDown() {
@@ -44,6 +48,6 @@ export function resetLicenseDropDown() {
 }
 
 export function loadUserDefaults() {
-  loadFilterSection(elements.useCaseChooserWrapper);
-  loadFilterSection(elements.licenseChooserWrapper);
+  loadFilterPreferences(elements.useCaseChooserWrapper);
+  loadFilterPreferences(elements.licenseChooserWrapper);
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -107,13 +107,14 @@ async function populateSourceList() {
     count += 1;
   });
 
-  loadSourcesToDom(sourcesList);
+  console.log(enableSearchStorageOption);
+  console.log(localStorage.length !== 0);
+  loadSourcesToDom(sourcesList, enableSearchStorageOption && localStorage.length !== 0);
 }
-
-populateSourceList();
 
 elements.filterIcon.addEventListener('click', () => {
   elements.filterSection.classList.toggle('section-filter--active');
+  populateSourceList();
 });
 
 // TODO: divide the steps into functions
@@ -337,7 +338,6 @@ $('#choose-license').comboTree({
   source: licensesList,
   isMultiple: true,
 });
-loadUserDefaults();
 
 function setEnableSearchStorageOptionVariable(enableSearchStorage) {
   if (enableSearchStorage === undefined) {
@@ -386,9 +386,11 @@ async function loadStoredSearchOnInit() {
       }
     } else {
       elements.clearSearchButton[0].classList.add('display-none');
+      loadUserDefaults();
     }
   });
 }
+
 loadStoredSearchOnInit();
 
 async function nextRequest(page) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -107,8 +107,6 @@ async function populateSourceList() {
     count += 1;
   });
 
-  console.log(enableSearchStorageOption);
-  console.log(localStorage.length !== 0);
   loadSourcesToDom(sourcesList, enableSearchStorageOption && localStorage.length !== 0);
 }
 


### PR DESCRIPTION
Fixes #236 

**Description**
A clash over which filters to load happens when the user has set some default filters for themselves and also enabled the feature of storing the last session in the Local Storage.  Ideally, those filters should be set, which results in the image present in the search section. Therefore the filters in the last stored session are loaded. 


**Other Information**
In case there is nothing in the Local Storage (either the user had toggled off the feature or they cleared the search results before ending the previous session), the default filters are loaded.


![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/34679965/80422670-388b2280-88fc-11ea-8849-8745275527c1.gif)

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

