### PR TITLE
load filters after a couple seconds and check if it's rendered before every search query

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -112,8 +112,9 @@ async function populateSourceList() {
 
 elements.filterIcon.addEventListener('click', () => {
   elements.filterSection.classList.toggle('section-filter--active');
-  populateSourceList();
 });
+
+setTimeout(populateSourceList(), 2500);
 
 // TODO: divide the steps into functions
 elements.filterResetButton.addEventListener('click', () => {
@@ -235,11 +236,19 @@ elements.filterApplyButton.addEventListener('click', () => {
   elements.searchIcon.click();
 });
 
+function checkIfSourceFilterIsRendered() {
+  if (elements.sourceChooserWrapper.style.display !== 'inline-block') {
+    showNotification('Loading Source Filters. Please try again!', 'negative', 'snackbar-bookmarks');
+    throw new Error('Source Filter not loaded yet');
+  }
+}
+
 elements.searchIcon.addEventListener('click', () => {
   inputText = elements.inputField.value.trim().replace('/[ ]+/g', ' ');
   pageNo = 1;
 
   checkInputError(inputText);
+  checkIfSourceFilterIsRendered();
   checkInternetConnection();
   removeNode('primary__initial-info');
   removeNode('no-image-found');


### PR DESCRIPTION
Fixes #246 

**Description**
Instead of triggering the API request for sources and rendering the dropdown after the user has clicked on the filter-icon, the API request is triggered after 2.5 seconds extension has loaded. 

As a separate check, if the user manages to enter a new query and press the search icon before 2.5-3 seconds, a notification is shown (Loading Source Filters. Please try again!).

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

