### PR TITLE
Fix bug - load more button appears below an empty search gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "CC Search Browser Extension.",
   "scripts": {
-    "lint": "eslint './src/**/*.js' './tests/**/*.js'",
+    "lint": "eslint \"./src/**/*.js\" \"./tests/**/*.js\"",
     "compile-sass-popup:dev": "node-sass src/popup/sass/main.scss src/popup/popup.css",
     "compile-sass-options:dev": "node-sass src/options/sass/main.scss src/options/options.css",
     "compile-sass-popup:prod": "node-sass src/popup/sass/main.scss src/popup/popup.css --output-style compressed",

--- a/src/popup/searchModule.js
+++ b/src/popup/searchModule.js
@@ -77,7 +77,10 @@ function appendToGrid(msnryObject, fragment, divs, grid) {
     msnryObject.layout();
   });
   removeSpinner(elements.spinnerPlaceholderPrimary);
-  addLoadMoreButton(elements.loadMoreSearchButtonWrapper);
+  // Don't show "load more results" button for empty searches
+  if (msnryObject.cols) {
+    addLoadMoreButton(elements.loadMoreSearchButtonWrapper);
+  }
 }
 
 // TODO: be more specific


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #287 

**Description**
<!-- Add your description below. -->
Updated `appendToGrid()` method in the file `./src/popup/searchModule.js`
Used the variable `msnryObject.cols` in the above method to check for empty results and display "load more results" button accordingly.

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

