### PR TITLE
added CheckResultLength function to nextRequest

### DIFF
--- a/src/popup/helper.js
+++ b/src/popup/helper.js
@@ -67,14 +67,15 @@ export function removeLoadMoreButton(loadMoreButtonWrapper) {
  * notify the user, and throw Error.
  * @param {Object[]} resultArray
  */
-export function checkResultLength(resultArray) {
+export function checkResultLength(resultArray, context) {
   if (resultArray.length === 0) {
-    showNotification(
-      'No Images Found. Please enter a different query.',
-      'negative',
-      'notification--extension-popup',
-      4000,
-    );
+    let message;
+    if (context === 'forSearch') {
+      message = 'No Images Found. Please enter a different query.';
+    } else if (context === 'forNextRequest') {
+      message = 'No more images found.';
+    }
+    showNotification(message, 'negative', 'notification--extension-popup', 4000);
     removeSpinner(elements.spinnerPlaceholderPrimary);
     removeLoadMoreButton(elements.loadMoreSearchButtonWrapper);
     primaryGridMasonryObject.layout();

--- a/src/popup/localUtils.js
+++ b/src/popup/localUtils.js
@@ -222,7 +222,7 @@ export function addImagesToDOM(masonryObject, imageObjects, gridDiv, forBookmark
  */
 export async function search(url) {
   const images = await fetchImages(url);
-  checkResultLength(images);
+  checkResultLength(images, 'forSearch');
   addImagesToDOM(primaryGridMasonryObject, images, elements.gridPrimary);
   appObject.pageNo += 1;
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -79,7 +79,7 @@ async function nextRequest() {
   console.log(url);
 
   const images = await fetchImages(url);
-  checkResultLength(images);
+  checkResultLength(images, 'forNextRequest');
   addImagesToDOM(primaryGridMasonryObject, images, elements.gridPrimary);
   appObject.pageNo += 1;
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -6,7 +6,7 @@ import {
   filterCheckboxWrappers,
 } from './base';
 import { checkInputError, getRequestUrl, getCollectionsUrl } from './searchModule';
-import { removeLoadMoreButton, clearFilters, removeImagesFromGrid, getTagsUrl } from './helper';
+import { removeLoadMoreButton, clearFilters, removeImagesFromGrid, getTagsUrl, checkResultLength } from './helper';
 import { fillImageDetailSection, resetImageDetailSection } from './imageDetailModule';
 import { addSpinner, removeSpinner } from './spinner';
 import {
@@ -79,6 +79,7 @@ async function nextRequest() {
   console.log(url);
 
   const images = await fetchImages(url);
+  checkResultLength(images);
   addImagesToDOM(primaryGridMasonryObject, images, elements.gridPrimary);
   appObject.pageNo += 1;
 }


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #295 

**Description**
Added checkResultLength function inside nextRequest function to solve the load more results button issue even when there are no new images to show.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

